### PR TITLE
Runoff remap files for the QU120 ocean grid are added.

### DIFF
--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -86,6 +86,14 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
     </gridmap>
+    <gridmap rof_grid="rx1" ocn_grid="oQU120" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">/glade/p/univ/ucsu0085/inputdata/rof_remap/wght_file_drof_qu120.230123.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">/glade/p/univ/ucsu0085/inputdata/rof_remap/wght_file_drof_qu120.230123.nc</map>
+    </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="oQU120" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">/glade/p/univ/ucsu0085/inputdata/rof_remap/wght_file_mosart_qu120.230123.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">/glade/p/univ/ucsu0085/inputdata/rof_remap/wght_file_mosart_qu120.230123.nc</map>
+    </gridmap>
 
     <!-- ======================================================== -->
     <!-- GRIDS: glc to ocn mapping                                -->


### PR DESCRIPTION
These are required because the default remapping fails to conserve with MPAS grids that are defined only where ocean exists.
The remap files are generated using ESMF
nearest_neighbor_dst_to_src and are conservative. One is generated for data-runoff (DROF) and one for the prognostic river-routing model (MOSART).
Remap files for other ocean grids will be added later.