### PR TITLE
Revert Derecho modules to ncarenv/23.06

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -1298,20 +1298,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <modules>
 	<command name="load">cesmdev/1.0</command>
-	<command name="load">ncarenv/23.09</command>
+	<command name="load">ncarenv/23.06</command>
         <command name="purge"/>
 	<command name="load">craype</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2023.2.1</command>
+        <command name="load">intel/2023.0.0</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel-oneapi">
-        <command name="load">intel-oneapi/2023.2.1</command>
+        <command name="load">intel-oneapi/2023.0.0</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel-classic">
-        <command name="load">intel-classic/2023.2.1</command>
+        <command name="load">intel-classic/2023.0.0</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="cray">
@@ -1323,7 +1323,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
       <modules compiler="nvhpc">
-        <command name="load">nvhpc/23.7</command>
+        <command name="load">nvhpc/23.5</command>
       </modules>
 
       <modules>
@@ -1331,14 +1331,14 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">cmake</command>
       </modules>
       <modules mpilib="mpich">
-	<command name="load">cray-mpich/8.1.27</command>
+	<command name="load">cray-mpich/8.1.25</command>
       </modules>
       <modules mpilib="mpi-serial">
         <command name="load">mpi-serial/2.3.0</command>
       </modules>
 
       <modules mpilib="mpich" compiler="nvhpc" gpu_offload="!none">
-        <command name="load">cuda/12.2.1</command>
+        <command name="load">cuda/11.7.1</command>
       </modules>
 
       <modules mpilib="mpi-serial">
@@ -1352,12 +1352,12 @@ This allows using a different mpirun command to launch unit tests
 
       <modules DEBUG="TRUE">
 	<command name="load">parallelio/2.6.2-debug</command>
-	<command name="load">esmf/8.6.0b04-debug</command>
+	<command name="load">esmf/8.6.0b03-debug</command>
       </modules>
 
       <modules DEBUG="FALSE">
 	<command name="load">parallelio/2.6.2</command>
-	<command name="load">esmf/8.6.0b04</command>
+	<command name="load">esmf/8.6.0b03</command>
       </modules>
     </module_system>
 


### PR DESCRIPTION
Allow fresh clones of EarthWorksOrg/EarthWorks to build on Derecho by reverting the modules and software stack from the new ncarenv/23.09 versions to the ncarenv/23.06 versions.

Fixes [EWOrg/EW #27](https://github.com/EarthWorksOrg/EarthWorks/issues/27)