### PR TITLE
Link CMake macros for intel-classic

### DIFF
--- a/machines/cmake_macros/intel-classic.cmake
+++ b/machines/cmake_macros/intel-classic.cmake
@@ -1,0 +1,1 @@
+intel.cmake

--- a/machines/cmake_macros/intel-classic_derecho.cmake
+++ b/machines/cmake_macros/intel-classic_derecho.cmake
@@ -1,0 +1,1 @@
+intel_derecho.cmake


### PR DESCRIPTION
Add necessary .cmake files for when COMPILER=intel-classic. Without these files, builds would fail in share stating "Unresolved MODULE PROCEDURE specification name."

Fixes [EWOrg EW #27](https://github.com/EarthWorksOrg/EarthWorks/issues/27) - intel-classic error.