### PR TITLE
Update 15km file defaults

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -434,8 +434,8 @@
       <support>Experimental, under development</support>
     </domain>
     <domain name="oQU015">
-      <nx>1851581</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU015/oQU015_ESMFmesh.230907.nc</mesh>
+      <nx>1850090</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU015/oQU015_ESMFmesh.241221.nc</mesh>
       <desc>oQU015 is a MPAS ocean grid that is roughly 1/8 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>


### PR DESCRIPTION
The default ocean/seaice files for 15km have been updated to use a new one that does not initially generate unstable transients.

These modifications are in the mpas-ocean PR#18, mpas-seaice PR#20, and ccs_config components.