### PR TITLE
Merge update/ocean3p75

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -440,17 +440,24 @@
       <support>Experimental, under development</support>
     </domain>
     <domain name="oQU0075">
-      <nx>1849027</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU0075/oQU0075_ESMFmesh.230907.nc</mesh>
-      <desc>oQU00375 is a MPAS ocean grid that is roughly 1/16 degree resolution:</desc>
+      <nx>7399783</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU0075/oQU0075_ESMFmesh.241221.nc</mesh>
+      <desc>oQU0075 is a MPAS ocean grid that is roughly 1/16 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>
     <domain name="oQU00375">
-      <nx>1849027</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU00375/oQU00375_ESMFmesh.230907nc</mesh>
+      <nx>29598824</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU00375/oQU00375_ESMFmesh.241221.nc</mesh>
       <desc>oQU00375 is a MPAS ocean grid that is roughly 1/32 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>
+    <domain name="oRR60-3WUS">
+      <nx>835536</nx>  <ny>1</ny>
+      <mesh driver="nuopc">/glade/work/dazlich/oRR60-3/oRR60-3WUS_ESMFmesh.nc</mesh>
+      <desc>oQU60-3wus is a MPAS ocean grid that s 3km region refinement over the western US:</desc>
+      <support>Experimental, under development</support>
+    </domain>
+
 
   <!-- ======================================================== -->
   <!-- ROF domains -->

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1517,6 +1517,28 @@
     <grid name="ocnice">oQU00375</grid>
     <mask>oQU00375</mask>
   </model_grid>
+
+  <model_grid alias="mpasa60-3wus_oRR60-3WUS" not_compset="_MOM">
+    <grid name="atm">mpasa60-3wus</grid>
+    <grid name="lnd">mpasa60-3wus</grid>
+    <grid name="ocnice">oRR60-3WUS</grid>
+    <mask>oRR60-3WUS</mask>
+  </model_grid>
+
+  <model_grid alias="mpasa60-3wus_mpasa60-3wus" not_compset="_MOM">
+    <grid name="atm">mpasa60-3wus</grid>
+    <grid name="lnd">mpasa60-3wus</grid>
+    <grid name="ocnice">mpasa60-3wus</grid>
+    <mask>mpasa60-3wus</mask>
+  </model_grid>
+
+  <model_grid alias="T62_oRR60-3WUS" not_compset="_MOM">
+    <grid name="atm">T62</grid>
+    <grid name="lnd">T62</grid>
+    <grid name="ocnice">oRR60-3WUS</grid>
+    <mask>oRR60-3WUS</mask>
+  </model_grid>
+
   <!-- END EarthWorks Specific, MPAS-A+MPAS-O grids -->
 
 


### PR DESCRIPTION
Merge branch update/ocean3p75

This is a collection of commits that do the following:
Defaults have been added/updated for higher (15km, 7.5km and 3.75km) resolutions.
Diagnostic output defaults have been added to better align ocean and seaice diagnostic files with month boundaries. This reduces data loss at a restart.
Ocean gpu code can be built and run. However, the gpu solution is different from the cpu solution and needs further debugging.
Ocean surface salinity forcing has been merged into one ocean code base. Ocean and seaice time managers now no longer use the ESMF library, but use esmf-emulating code E3SM provided with the code.

Components part of this PR:
ccs_config
cime
mpas-ocean 
mpas-seaice
mpas-framework
