### PR TITLE
Revert to nvhpc/24.3 stack on Derecho

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -36,7 +36,7 @@
       <cmd_path lang="python">$ENV{LMOD_ROOT}/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-      <modules compiler="!gnu">
+      <modules compiler="!(gnu|nvhpc)">
         <command name="load">cesmdev/1.0</command>
         <command name="load">ncarenv/24.12</command>
         <command name="purge"/>
@@ -45,7 +45,7 @@
         <command name="load">craype</command>
         <command name="load">cmake</command>
       </modules>
-      <modules compiler="gnu">
+      <modules compiler="gnu|nvhpc">
         <command name="load">cesmdev/1.0</command>
         <command name="load">ncarenv/23.09</command>
         <command name="purge"/>
@@ -69,22 +69,19 @@
       </modules>
       <modules compiler="nvhpc">
         <command name="load">nvhpc/24.11</command>
-        <command name="load">cray-libsci/24.03.0</command>
+        <command name="load">cray-libsci/23.09.1.1</command>
       </modules>
       <modules>
         <command name="load">ncarcompilers/1.0.0</command>
       </modules>
-      <modules mpilib="mpich" compiler="!gnu">
+      <modules mpilib="mpich" compiler="!(gnu|nvhpc)">
         <command name="load">cray-mpich/8.1.29</command>
       </modules>
-      <modules mpilib="mpich" compiler="gnu">
+      <modules mpilib="mpich" compiler="(gnu|nvhpc)">
         <command name="load">cray-mpich/8.1.27</command>
       </modules>
 
-      <modules mpilib="mpich" compiler="nvhpc" gpu_type="!none">
-        <command name="load">cuda/12.3.2</command>
-      </modules>
-      <modules mpilib="mpich" compiler="gnu" gpu_type="!none">
+      <modules mpilib="mpich" compiler="(gnu|nvhpc)" gpu_type="!none">
         <command name="load">cuda/12.2.1</command>
       </modules>
 
@@ -93,16 +90,16 @@
         <command name="load">netcdf/4.9.2</command>
       </modules>
 
-      <modules mpilib="!mpi-serial" compiler="!gnu">
+      <modules mpilib="!mpi-serial" compiler="!(gnu|nvhpc)">
         <command name="load">netcdf-mpi/4.9.2</command>
         <command name="load">parallel-netcdf/1.14.0</command>
       </modules>
-      <modules mpilib="!mpi-serial" compiler="gnu">
+      <modules mpilib="!mpi-serial" compiler="(gnu|nvhpc)">
         <command name="load">netcdf-mpi/4.9.2</command>
         <command name="load">parallel-netcdf/1.12.3</command>
       </modules>
 
-      <modules compiler="!gnu">
+      <modules compiler="!(gnu|nvhpc)">
         <command name="load">parallelio/2.6.4</command>
         <command name="load">esmf/8.8.0</command>
       </modules>
@@ -110,7 +107,7 @@
         <command name="load">parallelio/2.6.2-debug</command>
         <command name="load">esmf/8.6.0-debug</command>
       </modules>
-      <modules DEBUG="FALSE" compiler="gnu">
+      <modules DEBUG="FALSE" compiler="(gnu|nvhpc)">
         <command name="load">parallelio/2.6.2</command>
         <command name="load">esmf/8.6.0</command>
       </modules>


### PR DESCRIPTION
Continue to use older modules due to EarthWorksOrg/EarthWorks Issue#90 - memory leak with stacks using nvhpc/24.7 or newer.