### PR TITLE
new 30km ocean files

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -428,8 +428,8 @@
       <support>Experimental, under development</support>
     </domain>
     <domain name="oQU030">
-      <nx>462075</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU030/oQU030_ESMFmesh.230907.nc</mesh>
+      <nx>462000</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU030/oQU030_ESMFmesh.241221.nc</mesh>
       <desc>oQU030 is a MPAS ocean grid that is roughly 1/4 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -114,6 +114,14 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_jra_qu060.230613.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_jra_qu060.230613.nc</map>
     </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="oQU030" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_mosart_qu030.241221.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_mosart_qu030.241221.nc</map>
+    </gridmap>
+    <gridmap rof_grid="JRA025v2" ocn_grid="oQU030" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_jra_qu030.241221.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_jra_qu030.241221.nc</map>
+    </gridmap>
 
     <!-- ======================================================== -->
     <!-- MizuRoute mapping files -->


### PR DESCRIPTION
New 30km ocean files are now set as the default. The new files have had the domain adjusted so that seaice does not freeze the entire column.